### PR TITLE
Corriger le nom du produit sur la page d'accueil

### DIFF
--- a/apps/agri/templates/agri/home.html
+++ b/apps/agri/templates/agri/home.html
@@ -46,7 +46,7 @@
             <section class="fr-grid-row fr-mt-n1w" id="baseline">
               <div class="fr-col fr-col-lg-6 fr-pt-4w">
                 <h1 class="fr-mb-md-6w">Agriculteurs :<br>un projet, une difficulté ?</h1>
-                <h2 class="fr-mb-md-6w">Mes Aides Agri vous accompagne pour identifier des aides pertinentes ou le bon conseiller de proximité.</h2>
+                <h2 class="fr-mb-md-6w">{{ SITE_CONFIG.site_title }} vous accompagne pour identifier des aides pertinentes ou le bon conseiller de proximité.</h2>
                 <a class="fr-btn fr-btn--lg fr-mb-3w fr-mb-md-6w" href="{% url 'agri:step-1' %}">Racontez-nous !</a>
               </div>
             </section>
@@ -56,7 +56,7 @@
       <div>
         <div class="fr-container">
           <section id="proposition" class="fr-container fr-mt-n4w fr-mt-md-n12w fr-mb-6w fr-py-3w">
-            <h3 class="fr-text-title--blue-france">Mes Aides Agri, c'est :</h3>
+            <h3 class="fr-text-title--blue-france">{{ SITE_CONFIG.site_title }}, c'est :</h3>
 
         <div class="fr-grid-row fr-grid-row--space-around">
           <div class="fr-col-12 fr-col-md-3 fr-py-3w fr-py-md-0 fr-px-3w">


### PR DESCRIPTION
Comme le nom du produit apparaît dans plusieurs phrases, on avait oublié de changer ces phrases quand le nom du produit a évolué. Maintenant c'est dynamique.