### PR TITLE
Amélioration de la gestion des dépendances Javascript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,12 @@
       "name": "aides-agri",
       "version": "1.0.0",
       "dependencies": {
-        "@hotwired/stimulus": "^3.2.2",
-        "@sentry/browser": "^9.22.0",
-        "htmx.org": "^2.0.4"
+        "@hotwired/stimulus": "^3.0",
+        "@sentry/browser": "^9.0",
+        "htmx.org": "^2.0"
       },
       "devDependencies": {
-        "esbuild": "^0.25.4"
+        "esbuild": "^0.25"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
   },
   "private": true,
   "dependencies": {
-    "@hotwired/stimulus": "^3.2.2",
-    "htmx.org": "^2.0.4",
-    "@sentry/browser": "^9.22.0"
+    "@hotwired/stimulus": "^3.0",
+    "htmx.org": "^2.0",
+    "@sentry/browser": "^9.0"
   },
   "devDependencies": {
-    "esbuild": "^0.25.4"
+    "esbuild": "^0.25"
   }
 }


### PR DESCRIPTION
Continuer d'utiliser le spécifieur chapeau, mais avec des numéros de version bien plus larges. De cette manière, une PR ouverte par Dependabot ne changera que le `package-lock.json`, pas le `package.json`, qui lui restera modifié à la main pour marquer une nouvelle version majeure.