### PR TITLE
Correctif mineur sur la page de résultats

### DIFF
--- a/apps/agri/views.py
+++ b/apps/agri/views.py
@@ -356,7 +356,7 @@ class ResultsView(ResultsMixin, ListView):
                                         "extra_classes": "fr-icon-arrow-right-line fr-link--icon-right",
                                         "is_external": True,
                                     }
-                                    if aide.url_demarche
+                                    if aide.url_descriptif
                                     else {},
                                     {
                                         "url": aide.url_demarche,


### PR DESCRIPTION
Les liens externes vers le descriptif en cas de publication en mode minimal ne s’affichent pas.