### PR TITLE
Correctif sur le filtre d'aides par zone géographique

### DIFF
--- a/apps/aides/models.py
+++ b/apps/aides/models.py
@@ -351,21 +351,19 @@ class AideQuerySet(models.QuerySet):
             return self
 
         departement = commune.parent
+        region = departement.parent
         return self.filter(
             # Nationales
             models.Q(couverture_geographique=Aide.CouvertureGeographique.NATIONAL)
             |
             # Same region
-            models.Q(zones_geographiques__enfants=departement)
+            models.Q(zones_geographiques=region)
             |
             # Same departement
             models.Q(zones_geographiques=departement)
             |
-            # Organisme : same EPCI
-            models.Q(organisme__zones_geographiques__enfants=commune)
-            |
-            # Organisme : same commune
-            models.Q(organisme__zones_geographiques=commune)
+            # The commune itself
+            models.Q(zones_geographiques=commune)
         )
 
 


### PR DESCRIPTION
L'implémentation du filtre était trop coûteuse en SQL