### PR TITLE
Optimisation de workflow Github

### DIFF
--- a/.github/workflows/vendor-js-deps.yml
+++ b/.github/workflows/vendor-js-deps.yml
@@ -1,5 +1,8 @@
 name: Vendor JS dependencies
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - 'package-lock.json'
 
 concurrency:
   group: ${{ github.head_ref || github.ref }}


### PR DESCRIPTION
Ne jouer le workflow de vendoring des dépendances JS que si le `package-lock.json` est modifié.