### PR TITLE
Outil d’édition des aides : permettre à une fiche mère d’écraser les champs de ses fiches filles

### DIFF
--- a/apps/aides/admin/aide.py
+++ b/apps/aides/admin/aide.py
@@ -508,7 +508,21 @@ class AideAdmin(ExtraButtonsMixin, ConcurrentModelAdmin, VersionAdmin):
         else:
             return super().save_form(request, form, change)
 
-    def save_related(self, request, form, formsets, change):
+    def save_model(self, request, obj: Aide, *args) -> None:
+        super().save_model(request, obj, *args)
+        for child in obj.children.all():
+            for field in obj.derivable_fields:
+                setattr(child, field.name, getattr(obj, field.name))
+            child.save()
+
+    def save_related(
+        self, request, form: forms.BaseModelForm, formsets, change
+    ) -> None:
         if not change:
             return
         super().save_related(request, form, formsets, change)
+        obj: Aide = form.instance
+        for child in obj.children.all():
+            for field in obj.derivable_m2m_relationships:
+                getattr(child, field.name).set(getattr(obj, field.name).all())
+            child.save()

--- a/apps/aides/models.py
+++ b/apps/aides/models.py
@@ -431,6 +431,53 @@ class Aide(models.Model):
         MEDIUM = 5, "2. Moyen urgent, ou dure quelques mois"
         LOW = 2, "3. Pas urgent ou dure que quelques semaines"
 
+    @classmethod
+    def _get_derivable_fields(cls) -> list[models.Field]:
+        return [
+            f
+            for f in cls._meta.get_fields()
+            if f.editable
+            and f
+            not in {
+                field_descriptor.field
+                for field_descriptor in {
+                    Aide.id,
+                    Aide.is_derivable,
+                    Aide.parent,
+                    Aide.is_published,
+                    Aide.status,
+                    Aide.sneak_peek_token,
+                    Aide.assigned_to,
+                    Aide.cc_to,
+                    Aide.date_created,
+                    Aide.date_modified,
+                    Aide.internal_comments,
+                    Aide.first_published_at,
+                    Aide.last_published_at,
+                    Aide.slug,
+                    Aide.nom,
+                    Aide.description_de_base,
+                    Aide.raw_data,
+                }
+            }
+        ]
+
+    @property
+    def derivable_fields(self) -> list[models.Field]:
+        return [
+            f
+            for f in self.__class__._get_derivable_fields()
+            if not f.many_to_many and getattr(self, f.name)
+        ]
+
+    @property
+    def derivable_m2m_relationships(self) -> list[models.Field]:
+        return [
+            f
+            for f in self.__class__._get_derivable_fields()
+            if f.many_to_many and getattr(self, f.name).exists()
+        ]
+
     is_derivable = models.BooleanField(default=False, verbose_name="Est déclinable")
     is_published = models.BooleanField(default=False, verbose_name="Publiée")
     parent = models.ForeignKey(

--- a/apps/aides/tests/conftest.py
+++ b/apps/aides/tests/conftest.py
@@ -1,4 +1,4 @@
-from pytest_factoryboy import register
+from pytest_factoryboy import register, LazyFixture
 
 from aides.models import Aide, ZoneGeographique
 from aides.tests import factories  # noqa
@@ -27,6 +27,7 @@ register(
 register(
     factories.AideFactory,
     "aide_published_with_parent",
+    organisme=LazyFixture("organisme"),
     status=Aide.Status.VALIDATED,
     is_published=True,
     with_parent=True,

--- a/apps/aides/tests/factories.py
+++ b/apps/aides/tests/factories.py
@@ -114,6 +114,7 @@ class AideFactory(factory.django.DjangoModelFactory):
             return
         obj.parent = AideFactory.create(
             nom=f"Parent of {obj.nom}",
+            organisme=obj.organisme,
             status=models.Aide.Status.VALIDATED,
             is_published=True,
         )

--- a/apps/aides/tests/test_admin.py
+++ b/apps/aides/tests/test_admin.py
@@ -129,6 +129,60 @@ def test_derive_aide_departementale(
     assert set(derived.zones_geographiques.all()) == {zone_geographique_departement_13}
 
 
+@pytest.mark.parametrize(
+    "aide_published_with_parent__url_descriptif", ["https://beta.gouv.fr"]
+)
+def test_change_parent_aide_applies_changes_to_children(
+    monkeypatch,
+    admin_client,
+    aide_published_with_parent,
+    zone_geographique_departement_13,
+):
+    # we don't care about 2FA here, let's skip it
+    monkeypatch.setattr(django_otp_middleware, "is_verified", lambda u: True)
+
+    aide = aide_published_with_parent
+
+    # GIVEN a derived Aide
+    assert aide.parent.url_descriptif != aide.url_descriptif
+
+    # WHEN POSTing to change the parent Aide
+    url = reverse("admin:aides_aide_change", args=[aide.parent.pk])
+    res = admin_client.post(
+        url,
+        headers={"host": "localhost"},
+        data={
+            "nom": "Coucou trop bien",
+            "organisme": aide.parent.organisme_id,
+            "status": aide.parent.status,
+            "importance": aide.parent.importance,
+            "urgence": aide.parent.urgence,
+            "couverture_geographique": Aide.CouvertureGeographique.DEPARTEMENTAL,
+            "zones_geographiques": [zone_geographique_departement_13.pk],
+            "url_descriptif": "https://aides-agri.beta.gouv.fr",
+        },
+    )
+
+    # THEN the child Aide has been changed as well, but not everything
+    assert res.status_code == 302
+    aide.refresh_from_db()
+    # have changed on both parent and child
+    assert aide.parent.url_descriptif == "https://aides-agri.beta.gouv.fr"
+    assert aide.url_descriptif == aide.parent.url_descriptif
+    assert (
+        aide.parent.couverture_geographique == Aide.CouvertureGeographique.DEPARTEMENTAL
+    )
+    assert aide.couverture_geographique == aide.parent.couverture_geographique
+    assert set(aide.parent.zones_geographiques.all()) == {
+        zone_geographique_departement_13
+    }
+    assert set(aide.zones_geographiques.all()) == set(
+        aide.parent.zones_geographiques.all()
+    )
+    # have changed on parent only
+    assert aide.nom != aide.parent.nom
+
+
 @pytest.mark.parametrize("aide_published__organisme", [LazyFixture("organisme")])
 @pytest.mark.parametrize(
     "aide_published__couverture_geographique", [Aide.CouvertureGeographique.REGIONAL]


### PR DESCRIPTION
[Outil d’édition des aides : permettre à une fiche mère d’écraser les champs de ses fiches filles](https://www.notion.so/incubateur-masa/Outil-d-dition-des-aides-permettre-une-fiche-m-re-d-craser-les-champs-de-ses-fiches-filles-33dde24614be80a68507f0584943380f?v=1a0de24614be80cf96d4000c05e0e507&source=copy_link)