### PR TITLE
Correctif sur le slug des Aides

### DIFF
--- a/apps/aides/models.py
+++ b/apps/aides/models.py
@@ -737,8 +737,7 @@ class Aide(models.Model):
         )
 
     def save(self, *args, **kwargs):
-        if not self.slug:
-            self.slug = f"{slugify(self.organisme.nom) if self.organisme_id else 'organisme-inconnu'}-{slugify(self.nom)}"
+        self.slug = f"{slugify(self.organisme.nom) if self.organisme_id else 'organisme-inconnu'}-{slugify(self.nom)}"
         if self.is_published:
             if not self.can_be_published():
                 raise ValueError("This Aide cannot be published")

--- a/apps/aides/tests/test_models.py
+++ b/apps/aides/tests/test_models.py
@@ -7,6 +7,21 @@ from aides.models import Aide
 @pytest.mark.django_db
 class TestAide:
     @pytest.mark.parametrize(
+        "organisme__nom,aide__nom,aide__organisme",
+        [["Organisme de test", "Super aide de test", LazyFixture("organisme")]],
+    )
+    def test_compute_slug_on_save(self, organisme, aide):
+        # GIVEN an Aide with a given name that results in a predictable slug
+        assert aide.slug == "organisme-de-test-super-aide-de-test"
+
+        # WHEN changing the nom and saving
+        aide.nom = "Nouveau nom"
+        aide.save()
+
+        # THEN the slug has been changed
+        assert aide.slug == "organisme-de-test-nouveau-nom"
+
+    @pytest.mark.parametrize(
         "organisme__is_masa,type_aide__score_priorite_aides,theme__is_prioritaire,sujet__with_given_theme,aide__organisme,aide__with_given_type,aide__with_given_sujet,aide__importance,aide__urgence,aide__enveloppe_globale,aide__demande_du_pourvoyeur,aide__taille_cible_potentielle,aide__is_meconnue,aide__is_filiere_sous_representee,aide__is_territoire_en_deploiement,expected",
         [
             [


### PR DESCRIPTION
Finalement on souhaite changer le slug à chaque fois que le nom change, parce que le fonctionnement précédent (ne le changer qu'une seule fois) posait des problèmes lors de la duplication d'aide.

De plus, la vue de consultation d'une aide possède déjà un mécanisme de redirection si le slug reçu est différent du slug réel, donc pas de crainte à avoir de ce côté-là.