### PR TITLE
Améliorations des notifications internes

### DIFF
--- a/apps/aides/management/commands/aides_send_daily_admin_notifications.py
+++ b/apps/aides/management/commands/aides_send_daily_admin_notifications.py
@@ -3,27 +3,50 @@ from datetime import timedelta
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.mail import send_mail
 from django.core.management.base import BaseCommand
 from django.urls import reverse
 from django.utils.timezone import now
+from reversion.models import Revision
 
 from ...models import Aide
 
 
 class Command(BaseCommand):
+    @staticmethod
+    def _summary_of_revisions_for_an_aide(
+        aide: Aide, revisions: list[Revision], base_url: str
+    ):
+        summary = f"\n- {aide.organisme.nom_court}, {aide.nom} : {base_url}{reverse('admin:aides_aide_change', args=[aide.pk])}\n"
+        summary += "\n".join(
+            [
+                f"    - {rev.date_created.strftime('%Hh%M')}, {rev.user.username} : {rev.comment}"
+                for rev in revisions
+            ]
+        )
+        return summary
+
     def handle(self, *args, **options):
         base_url = settings.HTTP_SCHEME + get_current_site(None).domain
         subject = f"[Aides Agri {settings.ENVIRONMENT}] Notifications internes du jour"
         aides_assigned_to_users = defaultdict(set)
         aides_cced_to_users = defaultdict(set)
-        for aide in Aide.objects.filter(date_modified__gt=now() - timedelta(days=1)):
+        revisions_by_aide = defaultdict(list)
+        content_type = ContentType.objects.get_for_model(Aide)
+
+        for revision in Revision.objects.filter(
+            version__content_type=content_type,
+            date_created__gt=now() - timedelta(days=1),
+        ):
+            aide: Aide = revision.version_set.first().object
+            revisions_by_aide[aide.pk].append(revision)
             aides_assigned_to_users[aide.assigned_to_id].add(aide)
             for cc in aide.cc_to.all():
                 aides_cced_to_users[cc.pk].add(aide)
 
-        for user in get_user_model().objects.all():
+        for user in get_user_model().objects.filter(is_active=True, is_staff=True):
             if (
                 user.pk not in aides_assigned_to_users
                 and user.pk not in aides_cced_to_users
@@ -33,20 +56,18 @@ class Command(BaseCommand):
             aides_assigned = ""
             aides_cced = ""
             if user.pk in aides_assigned_to_users:
-                aides_assigned = "Aides qui te sont assignées :\n\n" + "\n".join(
-                    [
-                        f"- {aide.nom}, portée par {aide.organisme.nom} : {base_url}{reverse('admin:aides_aide_change', args=[aide.pk])}"
-                        for aide in aides_assigned_to_users[user.pk]
-                    ]
-                )
+                aides_assigned = "Aides qui te sont assignées :\n"
+                for aide in aides_assigned_to_users[user.pk]:
+                    aides_assigned += self._summary_of_revisions_for_an_aide(
+                        aide, revisions_by_aide[aide.pk], base_url
+                    )
 
             if user.pk in aides_cced_to_users:
-                aides_cced = "Aides dont tu es en CC :\n\n" + "\n".join(
-                    [
-                        f"- {aide.nom}, portée par {aide.organisme.nom} : {base_url}{reverse('admin:aides_aide_change', args=[aide.pk])}"
-                        for aide in aides_cced_to_users[user.pk]
-                    ]
-                )
+                aides_cced = "Aides dont tu es en CC :\n"
+                for aide in aides_cced_to_users[user.pk]:
+                    aides_cced += self._summary_of_revisions_for_an_aide(
+                        aide, revisions_by_aide[aide.pk], base_url
+                    )
 
             send_mail(
                 subject,

--- a/apps/aides/management/commands/aides_unpublish_aides_having_invalid_link.py
+++ b/apps/aides/management/commands/aides_unpublish_aides_having_invalid_link.py
@@ -32,7 +32,7 @@ class Command(BaseCommand):
         no_url_descriptif = set()
         unpublished = set()
         to_be_verified = set()
-        for aide in Aide.objects.published():
+        for aide in Aide.objects.published_validated():
             if not aide.url_descriptif:
                 no_url_descriptif.add(aide)
             status_code = self._do_request(aide.url_descriptif)

--- a/apps/aides/management/commands/aides_unpublish_aides_having_invalid_link.py
+++ b/apps/aides/management/commands/aides_unpublish_aides_having_invalid_link.py
@@ -1,7 +1,9 @@
 import logging
 
 import requests
+import reversion
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.management.base import BaseCommand
 from django.core.mail import send_mail
@@ -32,6 +34,7 @@ class Command(BaseCommand):
         no_url_descriptif = set()
         unpublished = set()
         to_be_verified = set()
+        superuser = get_user_model().objects.filter(is_superuser=True).first()
         for aide in Aide.objects.published_validated():
             if not aide.url_descriptif:
                 no_url_descriptif.add(aide)
@@ -40,10 +43,15 @@ class Command(BaseCommand):
             if status_code == 200:
                 continue
             elif status_code == 404:
-                aide.status = Aide.Status.ARCHIVED
-                aide.is_published = False
-                aide.internal_comments += f"\n\n{localtime().strftime('%d/%M/%Y %Hh%i')} : dépublication pour cause d’erreur 404"
-                aide.save()
+                with reversion.create_revision():
+                    aide.status = Aide.Status.ARCHIVED
+                    aide.is_published = False
+                    aide.internal_comments += f"\n\n{localtime().strftime('%d/%m/%Y %Hh%M')} : dépublication pour cause d’erreur 404"
+                    aide.save()
+                    reversion.set_user(superuser)
+                    reversion.set_comment(
+                        "Dépublication, archivage, et ajout d’une précision dans les commentaires internes."
+                    )
                 unpublished.add(aide)
             else:
                 to_be_verified.add((aide, status_code))


### PR DESCRIPTION
[Les notifications de mouvements des aides ne sont pas très utiles : je suis obligée d’aller dans le back-office et sur chaque aide pour comprendre ce qu’il s’est passé, alors que l’information des changements m’intéresse](https://www.notion.so/incubateur-masa/Les-notifications-de-mouvements-des-aides-ne-sont-pas-tr-s-utiles-je-suis-oblig-e-d-aller-dans-le--35ede24614be80b6b285dee07493d241?source=copy_link)

- Vérification des URLs des aides :
    - Ne pas vérifier les URLs des aides non validées
    - Créer une `Revision` avec un message pour chaque Aide dépubliée par ce mécanisme
- Notifications internes :
    - Ne pas envoyer de notifs aux utilisateurs non actifs et non staff
    - Ajouter les détails des `Revision`s décrivant les changements, que ce soit via l'admin ou via la commande de dépublication automatique