### PR TITLE
Correction sur la fiche d'aide : le commentaire de base juridique n'était pas affiché

### DIFF
--- a/apps/aides/templates/aides/aide_detail.html
+++ b/apps/aides/templates/aides/aide_detail.html
@@ -273,6 +273,11 @@ document.onreadystatechange = evt => {
               >
                 {{ base_juridique.libelle }}
               </a>
+              {% if base_juridique.commentaire %}
+                <p class="fr-text--sm fr-text-mention--grey fr-mb-1w">
+                  {{ base_juridique.commentaire }}
+                </p>
+              {% endif %}
             </li>
           {% endfor %}
         </ul>


### PR DESCRIPTION
[Base juridique : les commentaires n’apparaissent pas](https://www.notion.so/incubateur-masa/Base-juridique-les-commentaires-n-apparaissent-pas-366de24614be8091aab9fce169097492?source=copy_link)