### PR TITLE
Comptabiliser les clics vers l’extérieur via les étapes dans la fiche d’aide

### DIFF
--- a/apps/aides/templates/aides/aide_detail.html
+++ b/apps/aides/templates/aides/aide_detail.html
@@ -201,7 +201,11 @@ document.onreadystatechange = evt => {
         >
           {{ sections.etapes }}
         </h2>
-        <div class="fr-pl-4w fr-mb-4w">
+        <div class="fr-pl-4w fr-mb-4w"
+             data-matomo-target="trackableContent"
+             data-matomo-trackable-content-event-page="Aide"
+             data-matomo-trackable-content-event-name="Lien démarche via Étapes"
+        >
           {{ object.etapes|urlize|dsfr_md }}
         </div>
         {% endif %}

--- a/apps/ui/static/ui/controllers/matomo.js
+++ b/apps/ui/static/ui/controllers/matomo.js
@@ -1,8 +1,18 @@
 import { Controller } from "stimulus"
 
 export class Matomo extends Controller {
+  static targets = ["trackableContent"]
+
   trackEvent(evt) {
     var _paq = window._paq = window._paq || []
     _paq.push(['trackEvent', evt.target.dataset.eventPage, evt.target.dataset.eventName])
+  }
+
+  trackableContentTargetConnected(elt) {
+    elt.querySelectorAll("a[target=_blank]").forEach(link => {
+      link.dataset.eventPage = elt.dataset.matomoTrackableContentEventPage
+      link.dataset.eventName = elt.dataset.matomoTrackableContentEventName
+      link.addEventListener("click", evt => this.trackEvent(evt))
+    })
   }
 }


### PR DESCRIPTION
[Comptabiliser les clics vers l’extérieur via les étapes dans la fiche d’aide](https://app.notion.com/p/incubateur-masa/Comptabiliser-les-clics-vers-l-ext-rieur-via-les-tapes-dans-la-fiche-d-aide-367de24614be80958315d6357c42b492?v=1a0de24614be80cf96d4000c05e0e507&source=copy_link)