### PR TITLE
Script de création rétroactive des releases Github

### DIFF
--- a/scripts/create-releases-history/README.md
+++ b/scripts/create-releases-history/README.md
@@ -1,0 +1,30 @@
+# Création rétropactive d’historique de releases
+
+Ce script crée l’historique de releases Github manquant.
+
+## Spécifications
+
+* Nommage des releases Github : `YYYY-MM-DD-X` (`X` étant un incrément des releases du jour) ;
+* Nommage des tags Git : `release/YYYY-MM-DD-X` ;
+* Notes de release : auto-générées (une passe humaine doit ensuite être effectuée sur les releases marquantes).
+
+## Fonctionnement
+
+1. Récupération de l’historique des déploiements Scalingo, pour obtenir **une liste ordonnée de commits Git** ;
+2. Structuration de ces commits par jour en utilisant les données internes de Git, pour obtenir **une liste de commit par jour** ;
+3. Création, pour chaque jour/commit, d’un tag Git et d’une release Github.
+
+## Mode d’emploi
+
+### Pré-requis
+
+* [scalingo-cli](https://doc.scalingo.com/tools/cli/start)
+* [gh cli](https://cli.github.com/)
+
+### Lancement de la commande
+
+```shell
+uv run main.py
+```
+
+La commande est idempotente.

--- a/scripts/create-releases-history/main.py
+++ b/scripts/create-releases-history/main.py
@@ -1,0 +1,71 @@
+import subprocess
+from collections import defaultdict
+
+all_commits = []
+
+
+def get_commits_from_scalingo(page: int = 1) -> list[str]:
+    commits = []
+    res = subprocess.run(
+        [
+            "scalingo",
+            "--app",
+            "aides-agri-prod",
+            "deployments",
+            "--per-page",
+            "50",
+            "--page",
+            f"{page}",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    for line in res.stdout.split("\n"):
+        if "│" not in line:
+            continue
+        commit = line.split("│")[5].strip()
+        if commit == "GIT REF" or commit in commits:
+            continue
+        commits.append(commit)
+    return commits
+
+
+scalingo_page = 1
+while commits := get_commits_from_scalingo(page=scalingo_page):
+    scalingo_page += 1
+    all_commits.extend(commits)
+
+dates = defaultdict(list)
+for commit in reversed(all_commits):
+    result = subprocess.run(
+        ["git", "show", commit, "--no-patch", "--format=%cs"],
+        capture_output=True,
+        text=True,
+    )
+    commit_date = result.stdout.strip()
+    dates[commit_date].append(commit)
+
+for release_date, commits in dates.items():
+    for i, commit in enumerate(commits):
+        release_name = f"{release_date}-{i + 1}"
+        tag_name = f"release/{release_name}"
+        print(f"Création du tag Git {tag_name} sur le commit {commit}")
+        res = subprocess.run(["git", "tag", tag_name, commit])
+        if res != 0:
+            print("Le tag existe déjà, on saute ce commit")
+            continue
+        else:
+            print("OK")
+        print(f"Push vers Github du tag Git {tag_name}")
+        subprocess.run(["git", "push", "origin", "--tags", tag_name])
+        print(f"Création de la release Github {release_name}")
+        subprocess.run(
+            [
+                "gh",
+                "release",
+                "create",
+                tag_name,
+                f"-t {release_name}",
+                "--generate-notes",
+            ]
+        )


### PR DESCRIPTION
[Centraliser dans Notion les infos des mises à jour du site (démos vidéo + changelog)](https://app.notion.com/p/incubateur-masa/Centraliser-dans-Notion-les-infos-des-mises-jour-du-site-d-mos-vid-o-changelog-358de24614be80ca87e8c40192fbb593?v=1a0de24614be80cf96d4000c05e0e507&source=copy_link)