### PR TITLE
Appliquer les changements d’une fiche mère à tous les niveaux en-dessous d’elle

### DIFF
--- a/apps/aides/admin/aide.py
+++ b/apps/aides/admin/aide.py
@@ -585,12 +585,23 @@ class AideAdmin(ExtraButtonsMixin, ConcurrentModelAdmin, VersionAdmin):
         else:
             return super().save_form(request, form, change)
 
+    def _apply_field_changes_to_children(self, aide: Aide):
+        for child in aide.children.all():
+            for field in aide.derivable_fields:
+                setattr(child, field.name, getattr(aide, field.name))
+            child.save()
+            self._apply_field_changes_to_children(child)
+
+    def _apply_m2m_changes_to_children(self, aide: Aide):
+        for child in aide.children.all():
+            for field in aide.derivable_m2m_relationships:
+                getattr(child, field.name).set(getattr(aide, field.name).all())
+            child.save()
+            self._apply_m2m_changes_to_children(child)
+
     def save_model(self, request, obj: Aide, *args) -> None:
         super().save_model(request, obj, *args)
-        for child in obj.children.all():
-            for field in obj.derivable_fields:
-                setattr(child, field.name, getattr(obj, field.name))
-            child.save()
+        self._apply_field_changes_to_children(obj)
 
     def save_related(
         self, request, form: forms.BaseModelForm, formsets, change
@@ -599,7 +610,4 @@ class AideAdmin(ExtraButtonsMixin, ConcurrentModelAdmin, VersionAdmin):
             return
         super().save_related(request, form, formsets, change)
         obj: Aide = form.instance
-        for child in obj.children.all():
-            for field in obj.derivable_m2m_relationships:
-                getattr(child, field.name).set(getattr(obj, field.name).all())
-            child.save()
+        self._apply_m2m_changes_to_children(obj)

--- a/apps/aides/tests/conftest.py
+++ b/apps/aides/tests/conftest.py
@@ -32,3 +32,11 @@ register(
     is_published=True,
     with_parent=True,
 )
+register(
+    factories.AideFactory,
+    "aide_published_with_parent_and_grandparent",
+    organisme=LazyFixture("organisme"),
+    status=Aide.Status.VALIDATED,
+    is_published=True,
+    with_parent=LazyFixture("aide_published_with_parent"),
+)

--- a/apps/aides/tests/factories.py
+++ b/apps/aides/tests/factories.py
@@ -124,12 +124,15 @@ class AideFactory(factory.django.DjangoModelFactory):
     def with_parent(obj, create, value, **kwargs):
         if not value or not create:
             return
-        obj.parent = AideFactory.create(
-            nom=f"Parent of {obj.nom}",
-            organisme=obj.organisme,
-            status=models.Aide.Status.VALIDATED,
-            is_published=True,
-        )
+        if value is True:
+            obj.parent = AideFactory.create(
+                nom=f"Parent of {obj.nom}",
+                organisme=obj.organisme,
+                status=models.Aide.Status.VALIDATED,
+                is_published=True,
+            )
+        else:
+            obj.parent = value
         obj.save()
 
     @factory.post_generation

--- a/apps/aides/tests/test_admin.py
+++ b/apps/aides/tests/test_admin.py
@@ -135,19 +135,19 @@ def test_derive_aide_departementale(
 def test_change_parent_aide_applies_changes_to_children(
     monkeypatch,
     admin_client,
-    aide_published_with_parent,
+    aide_published_with_parent_and_grandparent,
     zone_geographique_departement_13,
 ):
     # we don't care about 2FA here, let's skip it
     monkeypatch.setattr(django_otp_middleware, "is_verified", lambda u: True)
 
-    aide = aide_published_with_parent
+    aide = aide_published_with_parent_and_grandparent
 
     # GIVEN a derived Aide
     assert aide.parent.url_descriptif != aide.url_descriptif
 
     # WHEN POSTing to change the parent Aide
-    url = reverse("admin:aides_aide_change", args=[aide.parent.pk])
+    url = reverse("admin:aides_aide_change", args=[aide.parent.parent_id])
     res = admin_client.post(
         url,
         headers={"host": "localhost"},
@@ -168,21 +168,31 @@ def test_change_parent_aide_applies_changes_to_children(
     # THEN the child Aide has been changed as well, but not everything
     assert res.status_code == 302
     aide.refresh_from_db()
-    # have changed on both parent and child
-    assert aide.parent.url_descriptif == "https://aides-agri.beta.gouv.fr"
+    # have changed on both parent, child and grandchild
+    assert aide.parent.parent.url_descriptif == "https://aides-agri.beta.gouv.fr"
+    assert aide.parent.url_descriptif == aide.parent.parent.url_descriptif
     assert aide.url_descriptif == aide.parent.url_descriptif
     assert (
-        aide.parent.couverture_geographique == Aide.CouvertureGeographique.DEPARTEMENTAL
+        aide.parent.parent.couverture_geographique
+        == Aide.CouvertureGeographique.DEPARTEMENTAL
+    )
+    assert (
+        aide.parent.couverture_geographique
+        == aide.parent.parent.couverture_geographique
     )
     assert aide.couverture_geographique == aide.parent.couverture_geographique
-    assert set(aide.parent.zones_geographiques.all()) == {
+    assert set(aide.parent.parent.zones_geographiques.all()) == {
         zone_geographique_departement_13
     }
+    assert set(aide.parent.zones_geographiques.all()) == set(
+        aide.parent.parent.zones_geographiques.all()
+    )
     assert set(aide.zones_geographiques.all()) == set(
         aide.parent.zones_geographiques.all()
     )
     # have changed on parent only
     assert aide.nom != aide.parent.nom
+    assert aide.nom != aide.parent.parent.nom
 
 
 @pytest.mark.parametrize("aide__organisme", [LazyFixture("organisme")])


### PR DESCRIPTION
[Appliquer les changements d’une fiche mère à tous les niveaux en-dessous d’elle](https://app.notion.com/p/incubateur-masa/Appliquer-les-changements-d-une-fiche-m-re-tous-les-niveaux-en-dessous-d-elle-397de24614be80a2be45f5158d664808?v=1a0de24614be80cf96d4000c05e0e507&source=copy_link)