### PR TITLE
Afficher le lien de partage pour relecture même si l'aide est publiée en mode minimal

### DIFF
--- a/apps/aides/models.py
+++ b/apps/aides/models.py
@@ -833,8 +833,8 @@ class Aide(models.Model):
         return self.status == Aide.Status.TO_BE_DERIVED
 
     @property
-    def is_to_be_validated_externally(self):
-        return not self.is_published and self.status == Aide.Status.REVIEW_EXPERT
+    def is_to_be_reviewed_by_expert(self):
+        return self.status == Aide.Status.REVIEW_EXPERT
 
     @property
     def is_complete(self):

--- a/apps/aides/templates/admin/aides/aide/change_form_object_tools.html
+++ b/apps/aides/templates/admin/aides/aide/change_form_object_tools.html
@@ -5,7 +5,7 @@
   {% if original.children.exists %}
   <li><a href="../../?parent__id__exact={{ original.pk }}">Voir les aides déclinées</a></li>
   {% endif %}
-  {% if original.is_to_be_validated_externally %}
+  {% if original.is_to_be_reviewed_by_expert %}
   <li>
     <a href="{% url 'aides:aide-sneak-peek' original.pk original.sneak_peek_token %}" target="_blank" class="viewsitelink">
       Lien de partage pour le bureau valideur (nouvel onglet)


### PR DESCRIPTION
[Impossible de partager une aide pour relecture si elle est publiée en mode minimal](https://app.notion.com/p/incubateur-masa/Impossible-de-partager-une-aide-pour-relecture-si-elle-est-publi-e-en-mode-minimal-3b2de24614be805d86c8cf413ea61652?v=1a0de24614be80cf96d4000c05e0e507&source=copy_link)